### PR TITLE
Add curl to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6-slim
 
 RUN set -e && \
   apt-get update && \
-  apt-get install -y git && \
+  apt-get install -y git curl && \
   pip install --upgrade pip && \
   apt-get clean
 


### PR DESCRIPTION
Add curl to docker image as it is needed to get a .gitignore file from gitignore.io