### PR TITLE
Fix gitlab host when port in url

### DIFF
--- a/utils/parse_env_variables.py
+++ b/utils/parse_env_variables.py
@@ -30,7 +30,7 @@ def parse_env_variables(output):
         except AttributeError:
             print(22)
     elif output == 'host_name':
-        print(re.search(r'https?://([^\/]*)', os.environ['GITLAB_URL']).group(1))
+        print(re.search(r'https?://([^\/:]*)', os.environ['GITLAB_URL']).group(1))
     else:
         print('Unknown output option: {}'.format(output))
 


### PR DESCRIPTION
Demo script breaks when gitlab host is accessed with non-standard port

Needed to solve: https://github.com/SwissDataScienceCenter/renku/pull/344