### PR TITLE
Allow rerunning the script on existing project

### DIFF
--- a/steps/3-create-project.py
+++ b/steps/3-create-project.py
@@ -41,7 +41,20 @@ projects = requests.get(
 
 for project_data in projects:
     if project_data['name'] == 'weather-zh':
-        print('\nProject already created.')
+        print('\nProject already created, unprotecting master branch.')
+
+        # Unprotect master branch
+        response = requests.put(
+            gitlab_url + '/api/v4/projects/{0}/repository/branches/master/unprotect'.format(project_data['id']),
+            headers=headers
+        )
+
+        if response.status_code != 200:
+            print('\nProblem unprotecting master branch of existing project.')
+            print(response.text)
+            print('Aborting...\n')
+            exit(1)
+
         break
 else:
     project_data = {

--- a/steps/4-initialize-repo.sh
+++ b/steps/4-initialize-repo.sh
@@ -54,4 +54,4 @@ if ! [ -z "$DOCKER" ]; then
 fi
 
 git remote add origin $REMOTE_REPO_URL
-git push --set-upstream origin master
+git push -f --set-upstream origin master

--- a/steps/analyze-data/9-commit.sh
+++ b/steps/analyze-data/9-commit.sh
@@ -26,4 +26,4 @@ rm -r notebooks
 cp -r ../demo-script/commits/04/notebooks ./
 git add notebooks
 git commit -m "Work on Ku Analyze Data"
-git push origin master
+git push -f origin master

--- a/steps/implement-reader/5-commit.sh
+++ b/steps/implement-reader/5-commit.sh
@@ -33,6 +33,6 @@ cp -r ../demo-script/commits/02/notebooks ./
 
 git add -A .
 git commit -m "Work on Ku Data Reader"
-git push origin master
+git push -f origin master
 
 pip install -e src/python/weather-ch

--- a/steps/preprocess-data/7-commit.sh
+++ b/steps/preprocess-data/7-commit.sh
@@ -29,4 +29,4 @@ git add ./notebooks/PreprocessData.ipynb
 git commit -m "Work on Ku Preprocess Data"
 pip install -e src/python/weather-ch
 renku run python -m weather_ch preprocess data/zh/homog_mo_SMA.txt data/zh/standardized.csv
-git push origin master
+git push -f origin master


### PR DESCRIPTION
Allow the demo-script to be re-run by unprotecting the master branch of an existing weather-zh project and force pushing to the remote repo.